### PR TITLE
Fix the link on the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://api.travis-ci.org/undoio/addons.svg?master)](https://travis-ci.org/undoio/addons)
+[![Build status](https://api.travis-ci.com/undoio/addons.svg?master)](https://travis-ci.com/undoio/addons)
 
 UDB Addons
 ==========


### PR DESCRIPTION
Travis seems to prefer the .com TLD nowadays, despite the .org link
still working for some things.