### PR TITLE
Use `breakpoints_suspended` instead of deprecated `suspend_breakpoints`

### DIFF
--- a/backtrace_with_time/backtrace_with_time.py
+++ b/backtrace_with_time/backtrace_with_time.py
@@ -22,7 +22,7 @@ class BacktraceWithTime(gdb.Command):
     def invoke(arg, from_tty):
         # We disable all breakpoints, so we can reverse up the stack without
         # hitting anything we shouldn't.
-        with udb.time.auto_reverting(), debugger_utils.suspend_breakpoints():
+        with udb.time.auto_reverting(), debugger_utils.breakpoints_suspended():
             # Get the whole backtrace.
             backtrace = debugger_utils.execute_to_string("where")
             backtrace = backtrace.splitlines()

--- a/reconstruct_file/reconstruct_file.py
+++ b/reconstruct_file/reconstruct_file.py
@@ -266,7 +266,7 @@ class ReconstructFile(gdb.Command):
         if gdb.selected_inferior().architecture().name() != "i386:x86-64":
             raise gdb.GdbError("Only 64-bit x86 is supported.")
 
-        with debugger_utils.suspend_breakpoints(), udb.time.auto_reverting():
+        with debugger_utils.breakpoints_suspended(), udb.time.auto_reverting():
             if opts.from_start:
                 with debugger_io.RedirectOutput("/dev/null"):
                     udb.time.goto_start()


### PR DESCRIPTION
`suspend_breakpoints` was deprecated in UDB 6.10.0 and will be removed in UDB 7.0.