### PR TITLE
[#61] Use supported `undo` module, not deprecated `undodb`.

### DIFF
--- a/_linters/mypy.ini
+++ b/_linters/mypy.ini
@@ -1,11 +1,5 @@
 [mypy]
 python_version = 3.6
 
-[mypy-undodb.debugger_extensions]
-ignore_missing_imports = True
-
-[mypy-undodb.udb_launcher]
-ignore_missing_imports = True
-
 [mypy-elftools.elf.elffile]
 ignore_missing_imports = True

--- a/backtrace_with_time/backtrace_with_time.py
+++ b/backtrace_with_time/backtrace_with_time.py
@@ -8,7 +8,7 @@ Copyright (C) 2019 Undo Ltd
 
 import gdb
 
-from undodb.debugger_extensions import (
+from undo.debugger_extensions import (
     debugger_utils,
     udb,
 )

--- a/count_calls/count_calls.py
+++ b/count_calls/count_calls.py
@@ -3,7 +3,7 @@
 import sys
 import textwrap
 
-from undodb.udb_launcher import (
+from undo.udb_launcher import (
     REDIRECTION_COLLECT,
     UdbLauncher,
 )

--- a/count_calls/count_calls_extension.py
+++ b/count_calls/count_calls_extension.py
@@ -1,6 +1,6 @@
 import gdb
 
-from undodb.debugger_extensions import udb
+from undo.debugger_extensions import udb
 
 
 def count_calls(func_name):

--- a/reconstruct_file/reconstruct_file.py
+++ b/reconstruct_file/reconstruct_file.py
@@ -18,7 +18,7 @@ from typing import Iterator, NoReturn, Optional
 
 import gdb
 
-from undodb.debugger_extensions import debugger_io, debugger_utils, udb
+from undo.debugger_extensions import debugger_io, debugger_utils, udb
 
 
 def iterate_events(condition: str) -> Iterator[None]:

--- a/regs_every_bb/regs_every_bb.py
+++ b/regs_every_bb/regs_every_bb.py
@@ -6,7 +6,7 @@ Copyright (C) 2019 Undo Ltd
 
 import gdb
 
-from undodb.debugger_extensions import (
+from undo.debugger_extensions import (
     debugger_utils,
     udb,
 )

--- a/sample_functions/sample_functions.py
+++ b/sample_functions/sample_functions.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 import gdb
 
-from undodb.debugger_extensions import (
+from undo.debugger_extensions import (
     debugger_utils,
     udb,
 )


### PR DESCRIPTION
The `undodb` name for the module was deprecated in UDB version 8.0, and will be removed in UDB version 9.0.

* Fixes #61