### PR TITLE
Require a known-good version of the MCP package.

### DIFF
--- a/private/manifest.json
+++ b/private/manifest.json
@@ -105,7 +105,7 @@
 	    "repo": "addons",
 	    "script": "explain/explain.py",
 	    "python_package_deps": [
-		"mcp[cli]",
+		"mcp[cli]==1.9.4",
 		"exceptiongroup"
 	    ],
 	    "python_package_dir": "explain_packages",


### PR DESCRIPTION
Newer versions are released rapidly and can change behaviour.  Currently, the latest version requires support for native modules which I don't think we yet support for addons.