### PR TITLE
Initial support for Amp coding agent

### DIFF
--- a/explain/system_prompt.md
+++ b/explain/system_prompt.md
@@ -10,4 +10,8 @@ is asking about current UDB_Server session, unless they explicitly state otherwi
 Report information that comes from the MCP server, do not make assumptions about the program's state
 or behaviour.
 
+You are acting as an agent, on behalf of the user. You should investigate as far as possible before
+stopping to present findings or ask further questions. If the user asks you about a bug or about
+what went wrong, persistently try to to root cause it before reporting back.
+
 The first user question will follow.


### PR DESCRIPTION
# Feature

This enables the Amp coding agent to act as a backend to the "explain" command.  Note that this implementation currently discards existing user configuration to "amp" in order to apply an MCP server configuration.

Select the coding agent using the `--agent` (`-a`) flag to `explain` or the `EXPLAIN_AGENT` environment variable.  Valid values for these are "claude" and "amp".

It is not possible to switch coding agent once one has been invoked during a session.

# Future work

I think we're now getting to the point where we'll want to refactor the Agent backends so we can support more of them (e.g. Google Gemini CLI, Goose, maybe Sourcegraph Cody if necessary).  This needs a bit more work so I propose to do it as a subsequent PR - I do have the structure already in place on a branch.