### PR TITLE
Explain rich support

### DIFF
--- a/explain/explain.py
+++ b/explain/explain.py
@@ -383,7 +383,10 @@ class UdbMcpGateway:
         #  * Use "reverse-step" to get back into the end of the function.
 
         # Step to next line.
-        self.udb.execution.next()
+        with gdbio.CollectOutput() as collector:
+            self.udb.execution.next()
+        if LOG_LEVEL == "DEBUG":
+            print(f"reverse_step_into_current_line internal step to next line: {collector.output}")
 
         # Now try to step back into the correct function.
         with gdbutils.temporary_breakpoints(), gdbio.CollectOutput() as collector:

--- a/explain/explain.py
+++ b/explain/explain.py
@@ -17,6 +17,7 @@ import random
 import re
 import socket
 import textwrap
+import unittest.mock
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Concatenate, ParamSpec, TypeAlias, TypeVar
@@ -548,6 +549,7 @@ def uexperimental__mcp__serve(udb: udb_base.Udb, args: Any) -> None:
         gdbutils.temporary_parameter("pagination", False),
         udb.replay_standard_streams.temporary_set(False),
         gdbutils.breakpoints_suspended(),
+        unittest.mock.patch.object(udb, "_volatile_mode_explained", True),
     ):
         run_server(gateway, args.port)
 
@@ -634,6 +636,7 @@ def explain(udb: udb_base.Udb, args: Any) -> None:
         gdbutils.temporary_parameter("pagination", False),
         udb.replay_standard_streams.temporary_set(False),
         gdbutils.breakpoints_suspended(),
+        unittest.mock.patch.object(udb, "_volatile_mode_explained", True),
     ):
         explanation = event_loop.run_until_complete(explain_query(agent, gateway, why))
 


### PR DESCRIPTION
An initial port of the "explain" command to make use of the Rich library (https://github.com/Textualize/rich).

The sequence in this PR is:

 * Initial misc cleanups.
 * Port existing display style to use the new `output_utils` API.
 * Update implementation to use Rich.

I'd sugggest that out of scope for now is:
 * Doing something sensible with terminal detection beyond `force_console=True` (although if there's a quick improvement we should have it).
 * Making TUI play nicely with this.  To be honest, it's already not going to be a great experience with `explain`.
 * Further fanciness (live progress spinners).
 * Formatting, source highlighting, etc *within* the "Result" part of the debugger calls.