### PR TITLE
Added flag --strict-mcp-config for users who have Gen2 enabled in their license

### DIFF
--- a/explain/claude_agent.py
+++ b/explain/claude_agent.py
@@ -121,6 +121,7 @@ class ClaudeAgent(BaseAgent):
                 "opus",
                 "--mcp-config",
                 mcp_config_path,
+                "--strict-mcp-config",
                 "--allowedTools",
                 allowed_tools,
                 "--output-format",


### PR DESCRIPTION
Added flag --strict-mcp-config so that even if you have Gen2 enabled in your license but have older Undo release the explain plugin can work